### PR TITLE
Add flake8 to requirements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,8 @@
 [flake8]
-max-line-length = 129
+max-line-length = 80
 exclude =
 	.git,
+	config.py,
 	__pycache__
 	env/*
 	venv/*

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from decouple import config as decouple_config
 class Config(object):
     # FLASK
     DEBUG = False
-    TESTING = False 
+    TESTING = False
     # JWT
     JWT_TOKEN_LOCATION = ['headers']
     JWT_ACCESS_TOKEN_EXPIRES = 20
@@ -27,7 +27,7 @@ class ProductionConfig(Config):
 
 class DevelopmentConfig(Config):
     # FLASK
-    TESTING = True 
+    TESTING = True
     DEBUG = True
 
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 # Local development dependencies go here
 -r base.txt
 
-python-dotenv==0.10.1
+flake8==3.7.8
 flask-shell-ipython==0.4.0
 ipdb==0.11
 python-dotenv==0.10.1


### PR DESCRIPTION
- Add flake8 to dev requirements.
- Set max line length as 80 (pep8 default)
- Remove some trailing whitespaces
- Ignore `config.py` file on flake8